### PR TITLE
Use bundle as backpack item w/ some free benefits!

### DIFF
--- a/src/main/java/olivermakesco/de/servback/BackpackGui.java
+++ b/src/main/java/olivermakesco/de/servback/BackpackGui.java
@@ -35,7 +35,7 @@ public class BackpackGui extends SimpleGui {
         this.slots = slots;
         this.stack = stack;
         setTitle(stack.getName());
-        NbtCompound nbt = stack.getOrCreateSubNbt("inventory");
+        NbtCompound nbt = stack.getOrCreateNbt();
         DefaultedList<ItemStack> list = DefaultedList.ofSize(slots+1, ItemStack.EMPTY);
         list.set(slots,stack);
         Inventories.readNbt(nbt,list);
@@ -69,10 +69,9 @@ public class BackpackGui extends SimpleGui {
             ItemStack stack = getSlotRedirect(i).getStack();
             inv.set(i,stack);
         }
-        NbtCompound invNbt = Inventories.writeNbt(new NbtCompound(), inv);
         NbtCompound root = stack.getNbt();
-        root.put("inventory", invNbt);
-        stack.setNbt(root);
+        NbtCompound invNbt = Inventories.writeNbt(root, inv);
+        stack.setNbt(invNbt);
     }
 
     @Override

--- a/src/main/java/olivermakesco/de/servback/BackpackItem.java
+++ b/src/main/java/olivermakesco/de/servback/BackpackItem.java
@@ -75,7 +75,7 @@ public class BackpackItem extends Item implements VirtualItem {
 
     @Override
     public Item getVirtualItem() {
-        return Items.CHEST;
+        return Items.BUNDLE;
     }
 
     @Override


### PR DESCRIPTION
Hey Oliver! I was thrilled to find this mod after a long while of searching through datapacks to find a decent backpack one. This blows all of them away and I'm super happy with how it works.

While using it though, it occurred to me that maybe a chest wasn't the optimal item to be using for the regular backpacks and I thought I would try my hand at replacing it with the bundle. In my initial testing, with just getVirtualItem replaced with BUNDLE, I rediscovered the neat tooltip that bundles provide and slightly rearranged the NBT layout to take advantage of this function. 

I've attached a couple of pictures that show what this looks like for the backpacks and am curious as to your thoughts!

Backpack without any items in it
![Bundle Empty](https://user-images.githubusercontent.com/40325423/139119998-3a5c082c-827c-434a-8de7-8982d7930fda.png)

Backpack with a stack or more of items in it (the blue bar indicates how full the bundle would be and since in Vanilla they can only hold a stack, this is full)
![Bundle Items](https://user-images.githubusercontent.com/40325423/139120016-05343652-ba81-4d59-907c-b0b83868d10f.png)

The tooltip shown by the backpack
![Bundle Hover](https://user-images.githubusercontent.com/40325423/139120026-0c5ed6a9-4eb4-44ec-8179-1b1277a84605.png)

The one thing that I do think suffers from this change is consistency in the items with the regular backpacks and the ender/global packs, but I really liked how this turned out anyways!
